### PR TITLE
hotfix: correct wrong by-what for ketsui-b 2022-02-08

### DIFF
--- a/yso-shmup-records/records/ketsui-b/2022-02-08
+++ b/yso-shmup-records/records/ketsui-b/2022-02-08
@@ -4,7 +4,7 @@
   "subjectId": "ketsui-b",
   "stage": "1-ALL",
   "score": "52448550",
-  "byWhat": "arcade-akatronics",
+  "byWhat": "ketsui-deathtiny-ps4",
   "comment": "진짜로 케츠이 1주 클리어를 하게 될 줄은 몰랐습니다... 몰리면 바로 봄을 쓰는 안전지향 플레이 + 어제보다 딱 1목숨 더 들고 온 상황 덕분인 것 같습니다! 다음번에는 실기로도 꼭 클리어 해보고 싶네요 ㅎㅎ",
   "thumbnailUrl": "https://read-only-api-endpoints-kuman514.vercel.app/yso-shmup-records/records/ketsui-b/images/2022-02-08_thumbnail.jpg",
   "originalImageUrl": "https://read-only-api-endpoints-kuman514.vercel.app/yso-shmup-records/records/ketsui-b/images/2022-02-08_original.jpg",


### PR DESCRIPTION
- Corrected `byWhat` from `arcade-akatronics` to `ketsui-deathtiny-ps4` for ketsui-b 2022-02-08.